### PR TITLE
Enhance AstroNvim with AI helpers and productivity tweaks

### DIFF
--- a/lua/plugins/enhanced-terminal.lua
+++ b/lua/plugins/enhanced-terminal.lua
@@ -42,6 +42,16 @@ return {
         enabled = false,
       },
     },
+    config = function(_, opts)
+      require('toggleterm').setup(opts)
+      local Terminal = require('toggleterm.terminal').Terminal
+      local lazygit = Terminal:new({ cmd = 'lazygit', hidden = true })
+      local python = Terminal:new({ cmd = 'python', hidden = true })
+      local node = Terminal:new({ cmd = 'node', hidden = true })
+      vim.keymap.set('n', '<leader>gg', function() lazygit:toggle() end, { desc = 'Toggle LazyGit' })
+      vim.keymap.set('n', '<leader>py', function() python:toggle() end, { desc = 'Toggle Python REPL' })
+      vim.keymap.set('n', '<leader>js', function() node:toggle() end, { desc = 'Toggle Node REPL' })
+    end,
   },
 }
 

--- a/lua/plugins/mason.lua
+++ b/lua/plugins/mason.lua
@@ -1,26 +1,22 @@
-if true then return {} end -- WARN: REMOVE THIS LINE TO ACTIVATE THIS FILE
+-- Mason configuration with automatic tool installation
 
 -- Customize Mason
 
 ---@type LazySpec
 return {
-  -- use mason-tool-installer for automatically installing Mason packages
+  { "williamboman/mason.nvim", opts = { ui = { border = "rounded" } } },
+  {
+    "williamboman/mason-lspconfig.nvim",
+    opts = { automatic_installation = true },
+  },
+  { "jay-babu/mason-nvim-dap.nvim", opts = { handlers = {} } },
   {
     "WhoIsSethDaniel/mason-tool-installer.nvim",
-    -- overrides `require("mason-tool-installer").setup(...)`
     opts = {
-      -- Make sure to use the names found in `:Mason`
       ensure_installed = {
-        -- install language servers
         "lua-language-server",
-
-        -- install formatters
         "stylua",
-
-        -- install debuggers
         "debugpy",
-
-        -- install any other package
         "tree-sitter-cli",
       },
     },

--- a/lua/plugins/user.lua
+++ b/lua/plugins/user.lua
@@ -38,6 +38,9 @@ return {
         "Do. Or do not. There is no try.",
         "The Force will be with you. Always.",
         "Now, witness the power of this fully armed and operational editor!",
+        "Stay on target!",
+        "May the source be with you.",
+        "Fear is the path to the dark side. Code bravely.",
       }
       math.randomseed(os.time())
       opts.section.footer.val = quotes[math.random(#quotes)]

--- a/lua/user/ai.lua
+++ b/lua/user/ai.lua
@@ -1,0 +1,6 @@
+local map = vim.keymap.set
+
+map('v', '<leader>ai', ':ChatGPTEditWithInstructions<CR>', { noremap = true, silent = true, desc = 'Refactor code with AI' })
+map('v', '<leader>ae', ':ChatGPTExplain<CR>', { noremap = true, silent = true, desc = 'Explain code with AI' })
+map('v', '<leader>at', ':ChatGPTComplete<CR>', { noremap = true, silent = true, desc = 'Generate tests with AI' })
+map('v', '<leader>ac', ':ChatGPT<CR>', { noremap = true, silent = true, desc = 'Codex mode' })

--- a/lua/user/init.lua
+++ b/lua/user/init.lua
@@ -1,5 +1,7 @@
 -- User configuration loaded by lazy.nvim
 require('user.autocmds')
 require('user.keymaps')
+require('user.ai')
+require('user.theme')
 
 return {}

--- a/lua/user/keymaps.lua
+++ b/lua/user/keymaps.lua
@@ -5,3 +5,11 @@ map('n', '<leader>ff', ':Telescope find_files<CR>', opts)
 map('n', '<leader>fg', ':Telescope live_grep<CR>', opts)
 map('n', '<leader>fb', ':Telescope buffers<CR>', opts)
 map('n', '<leader>fh', ':Telescope help_tags<CR>', opts)
+map('n', '<leader>p', ":lua require('telescope').extensions.project.project{}<CR>", opts)
+-- Toggleterm helpers
+map('n', '<leader>gg', ":lua require('toggleterm.terminal').Terminal:new({cmd='lazygit', hidden=true}):toggle()<CR>", opts)
+map('n', '<leader>py', ":lua require('toggleterm.terminal').Terminal:new({cmd='python', hidden=true}):toggle()<CR>", opts)
+map('n', '<leader>js', ":lua require('toggleterm.terminal').Terminal:new({cmd='node', hidden=true}):toggle()<CR>", opts)
+-- Run and debug shortcuts
+map('n', '<leader>r', ":w<CR>:!%:p<CR>", { noremap = true, silent = true, desc = 'Run current file' })
+map('n', '<leader>d', ":lua require('dap').continue()<CR>", { noremap = true, silent = true, desc = 'Debug current file' })

--- a/lua/user/plugins.lua
+++ b/lua/user/plugins.lua
@@ -20,4 +20,19 @@ return {
   { 'LinArcX/telescope-command-palette.nvim', lazy = true, dependencies = { 'nvim-telescope/telescope.nvim' }, config = function()
       require('telescope').load_extension('command_palette')
     end },
+  -- AI-assisted features
+  {
+    'jackMort/ChatGPT.nvim',
+    cmd = { 'ChatGPT', 'ChatGPTEditWithInstructions' },
+    dependencies = { 'MunifTanjim/nui.nvim' },
+    opts = {
+      api_key_cmd = 'echo $OPENAI_API_KEY',
+    },
+  },
+  -- Zen and Twilight for focused coding
+  { 'folke/zen-mode.nvim', cmd = 'ZenMode' },
+  { 'folke/twilight.nvim', cmd = 'Twilight' },
+  -- Enhanced project navigation
+  { 'nvim-telescope/telescope-frecency.nvim', lazy = true, dependencies = { 'tami5/sqlite.lua' } },
+  { 'nvim-telescope/telescope-project.nvim', lazy = true },
 }

--- a/lua/user/theme.lua
+++ b/lua/user/theme.lua
@@ -1,0 +1,7 @@
+local hour = tonumber(os.date('%H'))
+
+if hour >= 8 and hour < 18 then
+  vim.cmd('colorscheme catppuccin')
+else
+  vim.cmd('colorscheme substrata')
+end


### PR DESCRIPTION
## Summary
- integrate ChatGPT, zen-mode, twilight, and project plugins
- configure mason for auto-installing tools
- extend toggleterm for LazyGit and REPLs
- add dynamic theme switching and fun dashboard quotes
- map helper shortcuts for projects, terminals, run, and debug

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_686b2b172f10832f8a69b888d993b904